### PR TITLE
Fix missing `camera_indices` in `src/alpamayo1_5/test_inference.py` and fix prompt when with no nav text

### DIFF
--- a/src/alpamayo1_5/helper.py
+++ b/src/alpamayo1_5/helper.py
@@ -112,13 +112,10 @@ def create_message(
     if nav_text is not None:
         route_section = f"<|route_start|>{nav_text}<|route_end|>"
 
-    if nav_text is not None or use_nav_prompt:
-        prompt_text = (
-            "output the chain-of-thought reasoning of the driving process, "
-            "then output the future trajectory."
-        )
-    else:
-        prompt_text = "output the future trajectory."
+    prompt_text = (
+        "output the chain-of-thought reasoning of the driving process, "
+        "then output the future trajectory."
+    )
 
     user_text = f"{hist_traj_placeholder}{route_section}{prompt_text}"
 

--- a/src/alpamayo1_5/test_inference.py
+++ b/src/alpamayo1_5/test_inference.py
@@ -32,7 +32,9 @@ def main() -> None:
     print(f"Loading dataset for clip_id: {clip_id}...")
     data = load_physical_aiavdataset(clip_id, t0_us=5_100_000)
     print("Dataset loaded.")
-    messages = helper.create_message(data["image_frames"].flatten(0, 1))
+    messages = helper.create_message(
+        frames=data["image_frames"].flatten(0, 1), camera_indices=data["camera_indices"]
+    )
 
     model = Alpamayo1_5.from_pretrained("nvidia/Alpamayo-1.5-10B", dtype=torch.bfloat16).to("cuda")
     processor = helper.get_processor(model.tokenizer)


### PR DESCRIPTION
This MR fixes an inference bug in `src/alpamayo1_5/test_inference.py` where `camera_indices` was not included in `helper.create_message`, resulting in wrong prefilling sequences. Also we fix the helper to use the correct prompt_text when there is no nav_text provided.