### PR TITLE
Make Flash Attention 2 the actual default in inference

### DIFF
--- a/src/alpamayo1_5/models/alpamayo1_5.py
+++ b/src/alpamayo1_5/models/alpamayo1_5.py
@@ -98,6 +98,10 @@ class Alpamayo1_5(ReasoningVLA):
         if config.expert_cfg is not None:
             for key, value in config.expert_cfg.items():
                 setattr(expert_config, key, value)
+        # The diffusion expert does not support FlashAttention 2.
+        # Force sdpa for the expert in that case.
+        if expert_config._attn_implementation == "flash_attention_2":
+            expert_config._attn_implementation = "sdpa"
         self.expert = AutoModel.from_config(expert_config)
         # we don't need the embed_tokens of the expert model
         del self.expert.embed_tokens

--- a/src/alpamayo1_5/models/base_model.py
+++ b/src/alpamayo1_5/models/base_model.py
@@ -216,12 +216,15 @@ class ReasoningVLAConfig(PretrainedConfig):
         tokens_per_history_traj: int = 16,
         tokens_per_future_traj: int = 64,
         model_dtype: str = "bfloat16",
-        attn_implementation: str = "flash_attention_2",
+        attn_implementation: str | None = None,
         min_pixels: int | None = None,
         max_pixels: int | None = None,
         add_special_tokens: bool = False,
         **kwargs: Any,
     ) -> None:
+        if attn_implementation is None:
+            attn_implementation = "flash_attention_2"
+        kwargs["attn_implementation"] = attn_implementation
         super().__init__(**kwargs)
 
         self.vlm_name_or_path = vlm_name_or_path
@@ -291,6 +294,8 @@ class ReasoningVLA(PreTrainedModel, TrajectoryFusionMixin):
 
     config_class: type[ReasoningVLAConfig] = ReasoningVLAConfig
     base_model_prefix: str = "vlm"
+    _supports_sdpa: bool = True
+    _supports_flash_attn: bool = True
 
     def __init__(
         self,


### PR DESCRIPTION
The default load path was dropping the saved attn_implementation, so inference quietly ran on sdpa instead of FA2 as advertised. Plumb the default through ReasoningVLAConfig to the property transformers dispatches on, declare _supports_sdpa / _supports_flash_attn on ReasoningVLA, and route the expert to sdpa under FA2 (its 4D mask is not FA2-varlen compatible). VLM now hits flash kernels by default.