### PR TITLE
Point Alpamayo 1.5 recipes to shared repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,13 @@ Alpamayo 1.5 provides two inference methods:
 
 - **`generate_text`** -- Text-only generation for visual question answering (VQA). Returns extracted text fields.
 
+## Fine-tuning and Post-training Recipes
+
+SFT and RL post-training scripts are maintained in [Alpamayo Recipes](https://github.com/NVlabs/alpamayo-recipes):
+
+- [Alpamayo 1.5 SFT](https://github.com/NVlabs/alpamayo-recipes/tree/main/recipes/alpamayo1_5_sft)
+- [Alpamayo 1.x RL post-training](https://github.com/NVlabs/alpamayo-recipes/tree/main/recipes/alpamayo1_x_rl), including Alpamayo 1.5
+
 ## Project Structure
 
 ```

--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@
 
 </div>
 
+## Updates
+
+- [May 2026] SFT and RL post-training scripts are available in [Alpamayo Recipes](https://github.com/NVlabs/alpamayo-recipes): [Alpamayo 1.5 SFT](https://github.com/NVlabs/alpamayo-recipes/tree/main/recipes/alpamayo1_5_sft) and [Alpamayo 1.x RL post-training](https://github.com/NVlabs/alpamayo-recipes/tree/main/recipes/alpamayo1_x_rl).
+
 **📖 Please read the [HuggingFace Model Card](https://huggingface.co/nvidia/Alpamayo-1.5-10B) first!**
 The model card contains comprehensive details on model architecture, inputs/outputs, licensing, and tested hardware configurations. This GitHub README focuses on setup, usage, and frequently asked questions.
 


### PR DESCRIPTION
## Summary

- add a fine-tuning and post-training recipes section to the Alpamayo 1.5 README
- point Alpamayo 1.5 SFT users to the Alpamayo Recipes SFT guide
- point RL/post-training users to the Alpamayo 1.x RL recipe and note that it includes Alpamayo 1.5

## Notes

This is documentation-only.