### PR TITLE
Add evaluation subpackage with single-clip minADE evaluator

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,21 @@ python src/alpamayo1_5/test_inference.py
 In case you would like to obtain more trajectories and reasoning traces, please feel free to increase
 the `num_traj_samples` argument in the script.
 
+### Evaluation
+
+A structured CLI evaluator is available under `src/alpamayo1_5/evaluation/`.
+It loads a single clip, runs inference, computes **minADE** against the
+ground-truth future ego trajectory, and writes a JSON result file.
+
+```bash
+python src/alpamayo1_5/evaluation/single_clip_eval.py \
+    --num_traj_samples 16 \
+    --output outputs/eval.json
+```
+
+See [`src/alpamayo1_5/evaluation/README.md`](src/alpamayo1_5/evaluation/README.md)
+for the full list of options and the Python API.
+
 ### Interactive notebooks
 
 We provide notebooks that demonstrate the different capabilities of Alpamayo 1.5 under `notebooks/`, including standard model inference, incorporating navigation guidance, modifying the number of cameras, and visual question answering.
@@ -117,6 +132,10 @@ alpamayo_1.5_release/
 │       │   └── ...                      # Action space definitions
 │       ├── diffusion/
 │       │   └── ...                      # Diffusion model components
+│       ├── evaluation/
+│       │   ├── minade.py                # MinADE metric computation
+│       │   ├── single_clip_eval.py      # Single-clip evaluation CLI
+│       │   └── README.md                # Evaluation usage guide
 │       ├── geometry/
 │       │   └── ...                      # Geometry utilities and modules
 │       ├── models/

--- a/outputs/eval.json
+++ b/outputs/eval.json
@@ -1,0 +1,44 @@
+{
+  "clip_id": "030c760c-ae38-49aa-9ad8-f5650a545d26",
+  "t0_us": 5100000,
+  "num_traj_samples": 16,
+  "minADE": 0.1226201057434082,
+  "all_ADE": [
+    0.1226201057434082,
+    1.8462951183319092,
+    1.0175502300262451,
+    0.8476450443267822,
+    0.8216369152069092,
+    1.0901161432266235,
+    2.7647407054901123,
+    0.8469518423080444,
+    0.6784101724624634,
+    1.2902019023895264,
+    1.8363008499145508,
+    1.06730055809021,
+    0.5050860643386841,
+    0.6638834476470947,
+    0.34886372089385986,
+    0.8137099742889404
+  ],
+  "cot": [
+    [
+      "Nudge to the left to clear the construction equipment blocking the right side of our lane",
+      "Nudge to the left to clear the construction equipment blocking the right side of our lane",
+      "Nudge to the left to clear the construction equipment blocking the right side of our lane",
+      "Keep distance to the lead vehicle since it is directly ahead in our lane",
+      "Nudge to the left to clear the construction equipment blocking the right side of our lane",
+      "Keep distance to the lead vehicle since it is directly ahead in our lane",
+      "Nudge to the left to clear the construction equipment blocking the right side of our lane",
+      "Nudge to the left to clear the construction equipment blocking the right side of our lane",
+      "Nudge to the left to clear the construction cones blocking the right side of our lane",
+      "Nudge to the left to clear the construction equipment blocking the right side of our lane",
+      "Nudge to the left to clear the construction equipment blocking the right side of our lane",
+      "Nudge to the left to clear the construction equipment blocking the right side of our lane",
+      "Keep distance to the lead vehicle since it is directly ahead in our lane",
+      "Nudge to the left to clear the construction equipment blocking the right side of our lane",
+      "Nudge to the left to clear the construction equipment blocking the right side of our lane",
+      "Keep distance to the lead vehicle since it is directly ahead in our lane"
+    ]
+  ]
+}

--- a/src/alpamayo1_5/evaluation/README.md
+++ b/src/alpamayo1_5/evaluation/README.md
@@ -1,0 +1,131 @@
+# Evaluation
+
+This subpackage provides utilities for evaluating Alpamayo 1.5 trajectory
+prediction accuracy.
+
+## Contents
+
+| File | Description |
+|------|-------------|
+| `minade.py` | `MinADECalculator` — computes minADE over the XY plane for multi-sample predictions |
+| `single_clip_eval.py` | `SingleClipEvaluator` + CLI — runs the full load → infer → score pipeline on a single clip |
+
+## Metric: minADE
+
+**Average Displacement Error (ADE)** for sample *k*:
+
+```
+ADE_k = mean_t || pred_xy_k[t] - gt_xy[t] ||_2
+```
+
+**minADE** selects the best sample across *K* predicted trajectories:
+
+```
+minADE = min_k ADE_k
+```
+
+Only the XY plane is used (Z is ignored), consistent with the inline check
+in `test_inference.py`.
+
+## Quick Start
+
+### Single-clip evaluation (CLI)
+
+```bash
+python src/alpamayo1_5/evaluation/single_clip_eval.py
+```
+
+This runs on the default clip (`030c760c-ae38-49aa-9ad8-f5650a545d26`,
+`t0_us=5_100_000`) and writes results to `outputs/single_clip_eval.json`.
+
+#### Common options
+
+```bash
+python src/alpamayo1_5/evaluation/single_clip_eval.py \
+    --clip_id 030c760c-ae38-49aa-9ad8-f5650a545d26 \
+    --t0_us 5100000 \
+    --num_traj_samples 16 \
+    --attn_implementation sdpa \
+    --output outputs/my_run.json
+```
+
+| Flag | Default | Notes |
+|------|---------|-------|
+| `--clip_id` | `030c760c-ae38-49aa-9ad8-f5650a545d26` | PhysicalAI-AV clip ID |
+| `--t0_us` | `5100000` | Evaluation timestamp (µs) |
+| `--model_name` | `nvidia/Alpamayo-1.5-10B` | HF model ID or local path |
+| `--num_traj_samples` | `1` | Trajectory samples per call |
+| `--dtype` | `bfloat16` | `bfloat16 \| float16 \| float32` |
+| `--attn_implementation` | *(auto)* | Use `sdpa` if `flash-attn` is unavailable |
+| `--seed` | `42` | CUDA RNG seed for reproducibility |
+| `--no_stream` | *(streaming on)* | Disable HuggingFace dataset streaming |
+| `--output` | `outputs/single_clip_eval.json` | Result file path |
+
+### Python API
+
+```python
+from alpamayo1_5.evaluation import EvalConfig, SingleClipEvaluator
+
+cfg = EvalConfig(
+    clip_id="030c760c-ae38-49aa-9ad8-f5650a545d26",
+    num_traj_samples=16,
+    seed=42,
+)
+result = SingleClipEvaluator(cfg).run()
+print(f"minADE: {result['minADE']:.4f} m")
+```
+
+### Using `MinADECalculator` directly
+
+```python
+from alpamayo1_5.evaluation import MinADECalculator
+
+calculator = MinADECalculator()
+result = calculator.calculate(pred_xyz=pred_xyz, gt_future_xyz=data["ego_future_xyz"])
+print(result.min_ade, result.all_ade)
+```
+
+## Example output
+
+Console:
+
+```
+[1/4] Loading dataset: clip_id=030c760c-ae38-49aa-9ad8-f5650a545d26, t0_us=5100000
+[2/4] Loading model...
+[3/4] Running inference...
+[4/4] Calculating minADE...
+Result saved to: outputs/single_clip_eval.json
+
+========== Evaluation Result ==========
+clip_id:          030c760c-ae38-49aa-9ad8-f5650a545d26
+t0_us:            5100000
+num_traj_samples: 1
+minADE:           0.373767 m
+all_ADE:          [0.373767...]
+
+========== Predicted Trajectory (index=0) ==========
+  [00] x=   0.000  y=   0.000  z=   0.000
+  [01] x=   0.412  y=   0.023  z=  -0.001
+  ...
+
+========== Chain-of-Causation ==========
+Nudge to the left to clear the construction equipment blocking the right side of our lane
+```
+
+`outputs/single_clip_eval.json`:
+
+```json
+{
+  "clip_id": "030c760c-ae38-49aa-9ad8-f5650a545d26",
+  "t0_us": 5100000,
+  "num_traj_samples": 1,
+  "minADE": 0.3737667798995972,
+  "all_ADE": [0.3737667798995972],
+  "cot": [["Nudge to the left to clear the construction equipment ..."]]
+}
+```
+
+## Prerequisites
+
+Follow the [top-level README](../../../../README.md) to set up the environment
+and authenticate with HuggingFace before running evaluation.

--- a/src/alpamayo1_5/evaluation/__init__.py
+++ b/src/alpamayo1_5/evaluation/__init__.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Evaluation utilities for Alpamayo 1.5 trajectory prediction."""
+
+from alpamayo1_5.evaluation.minade import MinADECalculator, MinADEResult
+from alpamayo1_5.evaluation.single_clip_eval import EvalConfig, SingleClipEvaluator
+
+__all__ = [
+    "EvalConfig",
+    "MinADECalculator",
+    "MinADEResult",
+    "SingleClipEvaluator",
+]

--- a/src/alpamayo1_5/evaluation/minade.py
+++ b/src/alpamayo1_5/evaluation/minade.py
@@ -1,0 +1,113 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Minimum Average Displacement Error (minADE) computation for trajectory evaluation."""
+
+from dataclasses import dataclass
+
+import numpy as np
+import torch
+
+
+@dataclass
+class MinADEResult:
+    """Result of a minADE computation.
+
+    Attributes:
+        min_ade: Minimum ADE across all predicted trajectory samples, in meters.
+        all_ade: Per-sample ADE values, in meters.
+    """
+
+    min_ade: float
+    all_ade: list[float]
+
+
+class MinADECalculator:
+    """Computes minADE over the XY plane for multi-sample trajectory predictions.
+
+    The Average Displacement Error (ADE) for sample ``k`` is::
+
+        ADE_k = mean_t || pred_xy_k[t] - gt_xy[t] ||_2
+
+    The minimum is then taken across all ``K`` samples::
+
+        minADE = min_k ADE_k
+    """
+
+    def calculate(
+        self,
+        pred_xyz: torch.Tensor,
+        gt_future_xyz: torch.Tensor,
+    ) -> MinADEResult:
+        """Compute minADE between predicted and ground-truth trajectories.
+
+        Args:
+            pred_xyz: Predicted trajectory tensor.  Accepted shapes:
+                ``(B, G, K, T, 3)``, ``(B, K, T, 3)``, or ``(K, T, 3)``.
+            gt_future_xyz: Ground-truth future trajectory, shape ``(1, 1, T, 3)``.
+
+        Returns:
+            MinADEResult with ``min_ade`` and per-sample ``all_ade``.
+        """
+        pred_xy = self._extract_pred_xy(pred_xyz)  # (K, T, 2)
+        gt_xy = self._extract_gt_xy(gt_future_xyz)  # (T, 2)
+
+        diff = np.linalg.norm(pred_xy - gt_xy[None, :, :], axis=-1)  # (K, T)
+        ade_per_sample = diff.mean(axis=-1)  # (K,)
+
+        return MinADEResult(
+            min_ade=float(ade_per_sample.min()),
+            all_ade=[float(x) for x in ade_per_sample.tolist()],
+        )
+
+    def _extract_gt_xy(self, gt_future_xyz: torch.Tensor) -> np.ndarray:
+        """Extract XY coordinates from the ground-truth tensor.
+
+        Args:
+            gt_future_xyz: Shape ``(1, 1, T, 3)``.
+
+        Returns:
+            Array of shape ``(T, 2)``.
+        """
+        gt = gt_future_xyz.detach().cpu().numpy()
+        assert gt.ndim == 4, f"{gt.ndim=}, expected (1, 1, T, 3)"
+        return gt[0, 0, :, :2]
+
+    def _extract_pred_xy(self, pred_xyz: torch.Tensor) -> np.ndarray:
+        """Extract XY coordinates from the model output tensor.
+
+        Handles the shapes produced by
+        ``sample_trajectories_from_data_with_vlm_rollout``:
+
+        * ``(B, G, K, T, 3)`` — standard multi-sample output
+        * ``(B, K, T, 3)`` — without trajectory-group dimension
+        * ``(K, T, 3)`` — unbatched
+
+        Args:
+            pred_xyz: Model output trajectory tensor.
+
+        Returns:
+            Array of shape ``(K, T, 2)``.
+        """
+        pred = pred_xyz.detach().cpu().numpy()
+
+        if pred.ndim == 5:
+            return pred[0, 0, :, :, :2]
+        if pred.ndim == 4:
+            return pred[0, :, :, :2]
+        if pred.ndim == 3:
+            return pred[:, :, :2]
+
+        raise ValueError(f"Unsupported pred_xyz shape: {pred.shape}")

--- a/src/alpamayo1_5/evaluation/single_clip_eval.py
+++ b/src/alpamayo1_5/evaluation/single_clip_eval.py
@@ -1,0 +1,374 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Single-clip minADE evaluation for Alpamayo 1.5.
+
+Provides a structured CLI entry point and a reusable ``SingleClipEvaluator`` class
+that runs the full load → infer → score pipeline and writes a JSON result file.
+
+Example usage::
+
+    python src/alpamayo1_5/evaluation/single_clip_eval.py \\
+        --clip_id 030c760c-ae38-49aa-9ad8-f5650a545d26 \\
+        --num_traj_samples 16
+
+"""
+
+import argparse
+import json
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch
+
+from alpamayo1_5 import helper
+from alpamayo1_5.evaluation.minade import MinADECalculator
+from alpamayo1_5.load_physical_aiavdataset import load_physical_aiavdataset
+from alpamayo1_5.models.alpamayo1_5 import Alpamayo1_5
+
+logger = logging.getLogger(__name__)
+
+_DTYPE_MAP: dict[str, torch.dtype] = {
+    "bfloat16": torch.bfloat16,
+    "float16": torch.float16,
+    "float32": torch.float32,
+}
+
+
+@dataclass
+class EvalConfig:
+    """Configuration for :class:`SingleClipEvaluator`.
+
+    Attributes:
+        clip_id: PhysicalAI-AV clip ID to evaluate.
+        t0_us: Evaluation timestamp in microseconds.
+        model_name: HuggingFace model identifier or local path.
+        device: Target device (``"cuda"`` or ``"cpu"``).
+        dtype: Model floating-point precision.
+        attn_implementation: Attention backend override.  Pass ``"sdpa"`` when
+            ``flash-attn`` is not available.
+        num_traj_samples: Number of trajectory samples drawn per inference call.
+        top_p: Nucleus sampling probability for VLM decoding.
+        temperature: Sampling temperature for VLM decoding.
+        max_generation_length: Maximum number of tokens for VLM generation.
+        seed: Random seed for reproducible sampling.
+        maybe_stream: Whether to stream data from HuggingFace if not cached locally.
+        output: Path to write the JSON result file.
+    """
+
+    clip_id: str = "030c760c-ae38-49aa-9ad8-f5650a545d26"
+    t0_us: int = 5_100_000
+    model_name: str = "nvidia/Alpamayo-1.5-10B"
+    device: str = "cuda"
+    dtype: str = "bfloat16"
+    attn_implementation: str | None = None
+    num_traj_samples: int = 1
+    top_p: float = 0.98
+    temperature: float = 0.6
+    max_generation_length: int = 256
+    seed: int = 42
+    maybe_stream: bool = True
+    output: str = field(default="outputs/single_clip_eval.json")
+
+
+class SingleClipEvaluator:
+    """Evaluates Alpamayo 1.5 trajectory prediction on a single dataset clip.
+
+    Runs the full inference pipeline and reports minADE against the
+    ground-truth future ego trajectory.
+
+    Example::
+
+        cfg = EvalConfig(clip_id="030c760c-ae38-49aa-9ad8-f5650a545d26")
+        result = SingleClipEvaluator(cfg).run()
+        print(f"minADE: {result['minADE']:.4f} m")
+    """
+
+    def __init__(self, config: EvalConfig) -> None:
+        self.config = config
+        self.device = torch.device(config.device)
+        self.torch_dtype = _DTYPE_MAP[config.dtype]
+
+    def run(self) -> dict[str, Any]:
+        """Execute the full evaluation pipeline.
+
+        Returns:
+            A dict containing ``clip_id``, ``t0_us``, ``num_traj_samples``,
+            ``minADE``, ``all_ADE``, and (when available) ``cot``.
+        """
+        cfg = self.config
+
+        print(f"[1/4] Loading dataset: clip_id={cfg.clip_id}, t0_us={cfg.t0_us}")
+        data = load_physical_aiavdataset(
+            clip_id=cfg.clip_id,
+            t0_us=cfg.t0_us,
+            maybe_stream=cfg.maybe_stream,
+        )
+
+        print("[2/4] Loading model...")
+        model, processor = self._load_model_and_processor()
+
+        print("[3/4] Running inference...")
+        pred_xyz, extra = self._infer(model, processor, data)
+
+        print("[4/4] Calculating minADE...")
+        result = MinADECalculator().calculate(
+            pred_xyz=pred_xyz,
+            gt_future_xyz=data["ego_future_xyz"],
+        )
+
+        cot_text = _extract_cot(extra)
+        output = {
+            "clip_id": cfg.clip_id,
+            "t0_us": cfg.t0_us,
+            "num_traj_samples": cfg.num_traj_samples,
+            "minADE": result.min_ade,
+            "all_ADE": result.all_ade,
+            "cot": cot_text,
+        }
+
+        _save_result(output, Path(cfg.output))
+        _print_summary(output, pred_xyz)
+
+        return output
+
+    def _load_model_and_processor(self) -> tuple[Alpamayo1_5, Any]:
+        kwargs: dict[str, Any] = {"dtype": self.torch_dtype}
+        if self.config.attn_implementation:
+            kwargs["attn_implementation"] = self.config.attn_implementation
+
+        model = Alpamayo1_5.from_pretrained(self.config.model_name, **kwargs).to(self.device)
+        model.eval()
+        processor = helper.get_processor(model.tokenizer)
+        return model, processor
+
+    @torch.inference_mode()
+    def _infer(
+        self,
+        model: Alpamayo1_5,
+        processor: Any,
+        data: dict[str, Any],
+    ) -> tuple[torch.Tensor, Any]:
+        cfg = self.config
+        frames = data["image_frames"].flatten(0, 1)
+        messages = helper.create_message(
+            frames=frames,
+            camera_indices=data["camera_indices"],
+        )
+
+        tokenized_inputs = processor.apply_chat_template(
+            messages,
+            tokenize=True,
+            add_generation_prompt=False,
+            continue_final_message=True,
+            return_dict=True,
+            return_tensors="pt",
+        )
+        model_inputs = helper.to_device(
+            {
+                "tokenized_data": tokenized_inputs,
+                "ego_history_xyz": data["ego_history_xyz"],
+                "ego_history_rot": data["ego_history_rot"],
+            },
+            self.device,
+        )
+
+        if self.device.type == "cuda":
+            torch.cuda.manual_seed_all(cfg.seed)
+
+        with torch.autocast(
+            device_type=self.device.type,
+            dtype=self.torch_dtype,
+            enabled=self.device.type == "cuda",
+        ):
+            pred_xyz, _pred_rot, extra = (
+                model.sample_trajectories_from_data_with_vlm_rollout(
+                    data=model_inputs,
+                    top_p=cfg.top_p,
+                    temperature=cfg.temperature,
+                    num_traj_samples=cfg.num_traj_samples,
+                    max_generation_length=cfg.max_generation_length,
+                    return_extra=True,
+                )
+            )
+
+        return pred_xyz, extra
+
+
+# ---------------------------------------------------------------------------
+# Module-level helpers
+# ---------------------------------------------------------------------------
+
+
+def _extract_cot(extra: Any) -> Any:
+    if not isinstance(extra, dict) or "cot" not in extra:
+        return None
+    try:
+        return extra["cot"][0]
+    except Exception:
+        return str(extra["cot"])
+
+
+def _print_summary(output: dict[str, Any], pred_xyz: torch.Tensor) -> None:
+    print("\n========== Evaluation Result ==========")
+    print(f"clip_id:          {output['clip_id']}")
+    print(f"t0_us:            {output['t0_us']}")
+    print(f"num_traj_samples: {output['num_traj_samples']}")
+    print(f"minADE:           {output['minADE']:.6f} m")
+    print(f"all_ADE:          {output['all_ADE']}")
+
+    _print_trajectory(pred_xyz, traj_index=0)
+
+    if output.get("cot"):
+        print("\n========== Chain-of-Causation ==========")
+        print(output["cot"])
+
+
+def _print_trajectory(pred_xyz: torch.Tensor, traj_index: int = 0) -> None:
+    """Print XYZ waypoints for a single predicted trajectory.
+
+    Args:
+        pred_xyz: Model output tensor.  Accepted shapes:
+            ``(B, G, K, T, 3)``, ``(B, K, T, 3)``, ``(K, T, 3)``, ``(T, 3)``.
+        traj_index: Index of the trajectory sample to print.
+    """
+    pred = pred_xyz.detach().float().cpu()
+
+    if pred.ndim == 5:
+        traj = pred[0, 0, traj_index]
+    elif pred.ndim == 4:
+        traj = pred[0, traj_index]
+    elif pred.ndim == 3:
+        traj = pred[traj_index]
+    elif pred.ndim == 2:
+        traj = pred
+    else:
+        raise ValueError(f"Unsupported pred_xyz shape: {tuple(pred.shape)}")
+
+    print(f"\n========== Predicted Trajectory (index={traj_index}) ==========")
+    for i, point in enumerate(traj):
+        x, y = float(point[0]), float(point[1])
+        z = float(point[2]) if point.shape[0] > 2 else 0.0
+        print(f"  [{i:02d}] x={x:8.3f}  y={y:8.3f}  z={z:8.3f}")
+
+
+def _make_json_serializable(obj: Any) -> Any:
+    if isinstance(obj, np.ndarray):
+        return obj.tolist()
+    if isinstance(obj, np.generic):
+        return obj.item()
+    if isinstance(obj, torch.Tensor):
+        return obj.detach().cpu().tolist()
+    if isinstance(obj, dict):
+        return {str(k): _make_json_serializable(v) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return [_make_json_serializable(v) for v in obj]
+    return obj
+
+
+def _save_result(output: dict[str, Any], save_path: Path) -> None:
+    save_path.parent.mkdir(parents=True, exist_ok=True)
+    with save_path.open("w", encoding="utf-8") as f:
+        json.dump(_make_json_serializable(output), f, ensure_ascii=False, indent=2)
+    print(f"Result saved to: {save_path}")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Single-clip minADE evaluation for Alpamayo 1.5.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--clip_id",
+        type=str,
+        default="030c760c-ae38-49aa-9ad8-f5650a545d26",
+        help="PhysicalAI-AV clip ID.",
+    )
+    parser.add_argument(
+        "--t0_us",
+        type=int,
+        default=5_100_000,
+        help="Evaluation timestamp in microseconds.",
+    )
+    parser.add_argument("--model_name", type=str, default="nvidia/Alpamayo-1.5-10B")
+    parser.add_argument("--device", type=str, default="cuda", choices=["cuda", "cpu"])
+    parser.add_argument(
+        "--dtype",
+        type=str,
+        default="bfloat16",
+        choices=["bfloat16", "float16", "float32"],
+    )
+    parser.add_argument(
+        "--attn_implementation",
+        type=str,
+        default=None,
+        choices=[None, "sdpa", "flash_attention_2", "eager"],
+        help="Attention backend.  Use sdpa if flash-attn is unavailable.",
+    )
+    parser.add_argument(
+        "--num_traj_samples",
+        type=int,
+        default=1,
+        help="Number of sampled trajectories per inference call.",
+    )
+    parser.add_argument("--top_p", type=float, default=0.98)
+    parser.add_argument("--temperature", type=float, default=0.6)
+    parser.add_argument("--max_generation_length", type=int, default=256)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument(
+        "--no_stream",
+        action="store_true",
+        help="Disable HuggingFace dataset streaming.",
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        default="outputs/single_clip_eval.json",
+        help="Path to write the JSON result file.",
+    )
+    return parser
+
+
+def main() -> None:
+    """Run single-clip minADE evaluation from the command line."""
+    args = _build_parser().parse_args()
+    cfg = EvalConfig(
+        clip_id=args.clip_id,
+        t0_us=args.t0_us,
+        model_name=args.model_name,
+        device=args.device,
+        dtype=args.dtype,
+        attn_implementation=args.attn_implementation,
+        num_traj_samples=args.num_traj_samples,
+        top_p=args.top_p,
+        temperature=args.temperature,
+        max_generation_length=args.max_generation_length,
+        seed=args.seed,
+        maybe_stream=not args.no_stream,
+        output=args.output,
+    )
+    SingleClipEvaluator(cfg).run()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/alpamayo1_5/evaluation/single_clip_eval.py
+++ b/src/alpamayo1_5/evaluation/single_clip_eval.py
@@ -143,7 +143,7 @@ class SingleClipEvaluator:
         }
 
         _save_result(output, Path(cfg.output))
-        _print_summary(output, pred_xyz)
+        _print_summary(output, pred_xyz) 
 
         return output
 
@@ -232,9 +232,9 @@ def _print_summary(output: dict[str, Any], pred_xyz: torch.Tensor) -> None:
     print(f"minADE:           {output['minADE']:.6f} m")
     print(f"all_ADE:          {output['all_ADE']}")
 
-    _print_trajectory(pred_xyz, traj_index=0)
+    # _print_trajectory(pred_xyz, traj_index=0)
 
-    if output.get("cot"):
+    if output.get("cot") is not None:
         print("\n========== Chain-of-Causation ==========")
         print(output["cot"])
 


### PR DESCRIPTION
## Summary
This PR adds a structured evaluation subpackage (`src/alpamayo1_5/evaluation/`) to complement the existing `test_inference.py` smoke test with a reusable, CLI-friendly minADE evaluator.
**New files:**
- `evaluation/minade.py` — `MinADECalculator` class that computes ADE/minADE over the XY plane, handling all output shapes produced by `sample_trajectories_from_data_with_vlm_rollout`
- `evaluation/single_clip_eval.py` — `SingleClipEvaluator` class + `argparse` CLI that runs the full load → infer → score → JSON pipeline
- `evaluation/__init__.py` — package exports
- `evaluation/README.md` — usage guide with CLI flags and Python API examples
**Updated files:**
- `README.md` — added an Evaluation subsection and updated the project structure table
## Motivation
`test_inference.py` computes minADE inline as a sanity check. This PR extracts that logic into a proper, importable module so that:
1. The metric can be reused across scripts and notebooks without copy-pasting.
2. Users can run evaluations from the command line with configurable parameters (`--num_traj_samples`, `--seed`, `--attn_implementation`, etc.) and get structured JSON output.
3. The evaluator can serve as a baseline for future evaluation extensions.
The implementation intentionally reuses `helper.create_message`, `helper.to_device`, `helper.get_processor`, and `load_physical_aiavdataset` — no logic is duplicated from existing modules.
## Usage
```bash
# Quick run (defaults match test_inference.py)
python src/alpamayo1_5/evaluation/single_clip_eval.py
# Multi-sample, without flash-attn
python src/alpamayo1_5/evaluation/single_clip_eval.py \
    --num_traj_samples 16 \
    --attn_implementation sdpa \
    --output outputs/eval.json
```
```python
from alpamayo1_5.evaluation import EvalConfig, SingleClipEvaluator
result = SingleClipEvaluator(EvalConfig(num_traj_samples=16)).run()
print(f"minADE: {result['minADE']:.4f} m")
```
## Questions for maintainers
Additional metrics: Are there other evaluation metrics (e.g. minFDE, collision rate, comfort metrics) that you plan to standardize? Happy to extend minade.py or add a separate module to align with an internal eval protocol.
Multi-clip evaluation: Would a batch evaluator over a held-out clip list (e.g. from vla_golden.parquet) be a useful follow-up?
Test coverage: Should a pytest unit test be added for MinADECalculator (e.g. with synthetic tensors)? The pyproject.toml already lists pytest as a dev dependency.
## Test plan

 Ran single_clip_eval.py on the default clip (030c760c-..., t0_us=5_100_000, seed=42) — minADE matches test_inference.py output (~0.374 m)

 Verified from alpamayo1_5.evaluation import SingleClipEvaluator resolves correctly after package install

 No linter errors (Ruff, line-length 100)