### PR TITLE
docs(support): add issue templates + README support banner

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_template.md
+++ b/.github/ISSUE_TEMPLATE/bug_report_template.md
@@ -1,0 +1,33 @@
+---
+name: Bug report
+about: Create a bug report to help us improve Alpamayo
+title: "[BUG]"
+labels: "? - Needs Triage, bug"
+assignees: 'yesfandiari'
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**Steps/Code to reproduce bug**
+Follow this guide http://matthewrocklin.com/blog/work/2018/02/28/minimal-bug-reports to craft a minimal bug report. This helps us reproduce the issue and resolve it more quickly.
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Environment overview (please complete the following information)**
+ - Deployment: [local from source (uv), Slurm, or Cloud (specify provider)]
+ - Install method: `uv venv` + `uv sync` — paste `uv --version` and Python version (3.12 expected)
+ - flash-attn: compiled from source (CUDA Toolkit 12.x + `nvcc`) or PyTorch SDPA fallback?
+ - Model checkpoint: [e.g. nvidia/Alpamayo-1.5-10B]; HuggingFace gated access granted? (yes/no)
+ - Dataset: PhysicalAI-Autonomous-Vehicles access granted? (yes/no)
+
+**Environment details**
+ - Hardware: GPU type(s) and VRAM (~24 GB single-sample, ~40 GB multi-sample, ~60 GB with CFG; H100 80GB tested), number of GPUs
+ - Operating System
+ - CUDA Toolkit / NVIDIA driver version (from `nvcc --version` and `nvidia-smi`)
+ - Inference settings: `num_traj_samples`, CFG on/off, and script/notebook used (`src/alpamayo1_5/test_inference.py` or a notebook under `notebooks/`)
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,16 @@
+# .github/ISSUE_TEMPLATE/config.yml — Alpamayo family
+# Place this file at .github/ISSUE_TEMPLATE/config.yml in the repo root.
+#
+# GitHub Issues is reserved for code-level bugs, documentation
+# requests, and feature requests. Usage questions route via the contact_link
+# below; security reporting is handled by the repo's SECURITY.md — GitHub adds
+# its own "Report a security vulnerability" link automatically, so we do NOT
+# ship one here (avoids a duplicate security entry in the chooser).
+
+blank_issues_enabled: false
+
+contact_links:
+  - name: 💬 Submit a question (usage, how-to)
+    url: https://forums.developer.nvidia.com/c/autonomous-vehicles/alpamayo/766
+    about: >
+      For usage questions and discussion, post on the Alpamayo NV Developer Forum category. GitHub Issues is reserved for code-level bugs, documentation fixes, and feature requests.

--- a/.github/ISSUE_TEMPLATE/documentation_request_template.md
+++ b/.github/ISSUE_TEMPLATE/documentation_request_template.md
@@ -1,0 +1,35 @@
+---
+name: Documentation request
+about: Report incorrect or needed documentation for Alpamayo
+title: "[DOC]"
+labels: "? - Needs Triage, doc"
+assignees: 'yesfandiari'
+
+---
+
+## Report incorrect documentation
+
+**Location of incorrect documentation**
+Provide links and line numbers if applicable (e.g. the README, the HuggingFace model card, or notebooks under `notebooks/`).
+
+**Describe the problems or issues found in the documentation**
+A clear and concise description of what you found to be incorrect.
+
+**Steps taken to verify documentation is incorrect**
+List any steps you have taken:
+
+**Suggested fix for documentation**
+Detail proposed changes to fix the documentation if you have any.
+
+---
+
+## Report needed documentation
+
+**Report needed documentation**
+A clear and concise description of what documentation you believe is needed and why.
+
+**Describe the documentation you'd like**
+A clear and concise description of what you want to happen.
+
+**Steps taken to search for needed documentation**
+List any steps you have taken:

--- a/.github/ISSUE_TEMPLATE/feature_request_template.md
+++ b/.github/ISSUE_TEMPLATE/feature_request_template.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for Alpamayo
+title: "[FEA]"
+labels: "? - Needs Triage, feature request"
+assignees: 'yesfandiari'
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I wish I could use Alpamayo 1.5 to do [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context, code examples, or references to existing implementations about the feature request here.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@
 **📖 Please read the [HuggingFace Model Card](https://huggingface.co/nvidia/Alpamayo-1.5-10B) first!**
 The model card contains comprehensive details on model architecture, inputs/outputs, licensing, and tested hardware configurations. This GitHub README focuses on setup, usage, and frequently asked questions.
 
+## Support
+
+📣 **Usage questions and discussion about Alpamayo 1.5**: please join us on the [Alpamayo NV Developer Forum](https://forums.developer.nvidia.com/c/autonomous-vehicles/alpamayo/766).
+
+🐛 **Code-level bugs, documentation issues, and feature requests**: file a [GitHub issue](../../issues/new/choose) using the appropriate template (Bug report, Documentation request, or Feature request). The relevant NVIDIA responder is auto-assigned via the `assignees:` field on the template.
+
+🚨 **Security vulnerabilities**: please use [NVIDIA's Vulnerability Disclosure Program](https://app.intigriti.com/programs/nvidia/nvidiavdp/detail). Do not file security issues publicly here.
+
 ## Prerequisites
 
 - **NVIDIA GPU** with CUDA support


### PR DESCRIPTION
## What this PR does

Adds the uniform NVIDIA AV support chooser to this repo (body text customized for **Alpamayo 1.5**; the chooser structure stays uniform across the Alpamayo family):

- `.github/ISSUE_TEMPLATE/config.yml` — `blank_issues_enabled: false`; single **Submit a question** contact link → Alpamayo NV Developer Forum.
- `bug_report_template.md`, `documentation_request_template.md`, `feature_request_template.md` — `[BUG]` / `[DOC]` / `[FEA]` prefixes, auto-assign `yesfandiari`.
- `## Support` banner in the README (routing: Forum / GitHub Issues / NVIDIA VDP).

GitHub adds its own **Report a security vulnerability** link to the chooser automatically from the repo's `SECURITY.md`, so this PR intentionally ships no security link.

## Human-only checklist (after review)

- [ ] Grant `yesfandiari` **Triage** access (Settings → Collaborators) — GitHub silently drops auto-assignment if the user isn't a collaborator.
- [ ] Review + merge this PR.
- [ ] Visit [`/issues/new/choose`](https://github.com/NVlabs/alpamayo1.5/issues/new/choose) and confirm the 3 templates + **Submit a question** + the auto-added **Report a security vulnerability** link appear.
- [ ] File a test issue → confirm `yesfandiari` is auto-notified → close it.

## Banner placement

Placed just above `## Prerequisites`. Position is the repo owner's call — move it if you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
